### PR TITLE
Added option to stop a stream

### DIFF
--- a/Record3DUnityStreaming.cpp
+++ b/Record3DUnityStreaming.cpp
@@ -3,6 +3,9 @@
 #include <record3d/Record3DStructs.h>
 #include <record3d/Record3DStream.h>
 #include <cmath>
+#include <map>
+
+std::map<int32_t, Record3D::Record3DStream*> streams;
 
 
 FrameMetadata GetFrameMetadata()
@@ -60,6 +63,8 @@ static float InterpolateDepth(const float* $depthData, float $x, float $y, int $
 bool StartStreaming(Record3DDevice $deviceHandle, OnNewFrameCallback $newFrameCallback, OnStreamStoppedCallback $streamStoppedCallback)
 {
     auto* stream = new Record3D::Record3DStream{};
+    streams[$deviceHandle.handle] = stream;
+    
     constexpr int numComponentsPerPointPosition = 4;
 
     size_t positionsBufferSize = 0;
@@ -144,4 +149,17 @@ bool StartStreaming(Record3DDevice $deviceHandle, OnNewFrameCallback $newFrameCa
 
     bool connectionEstablished = stream->ConnectToDevice(dev);
     return connectionEstablished;
+}
+
+void StopStreaming(Record3DDevice $deviceHandle)
+{
+    if (streams.count($deviceHandle.handle) > 0)
+    {
+        Record3D::Record3DStream* stream = streams[$deviceHandle.handle];
+
+        if (stream != NULL)
+        {
+            stream->Disconnect();
+        }
+    }
 }

--- a/include/record3d_unity_streaming/Record3DUnityStreaming.h
+++ b/include/record3d_unity_streaming/Record3DUnityStreaming.h
@@ -53,6 +53,7 @@ extern "C"
     typedef void (*OnNewFrameCallback)(FrameInfo);
     typedef void (*OnStreamStoppedCallback)();
 	EXPORT_DLL bool StartStreaming(Record3DDevice $deviceHandle, OnNewFrameCallback $newFrameCallback, OnStreamStoppedCallback $streamStoppedCallback);
+    EXPORT_DLL void StopStreaming(Record3DDevice $deviceHandle);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Recent versions of Unity seem to crash when hitting play a second time. It seems that is is due to the processing thread not being exited properly after the first time it is launched. Then I added the option to manually close it. I had to change the scope of the stream to be able to close it. A map of the running streams has been added to keep the possibility to have several streams running at the same time.